### PR TITLE
feat: Add support for ignore_in_tests Table flag

### DIFF
--- a/codegen/builder.go
+++ b/codegen/builder.go
@@ -10,16 +10,17 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/cloudquery/cq-provider-sdk/provider/schema"
+	"github.com/hashicorp/go-hclog"
+	"github.com/iancoleman/strcase"
+	"github.com/jinzhu/inflection"
+
 	"github.com/cloudquery/cq-gen/code"
 	"github.com/cloudquery/cq-gen/codegen/config"
 	"github.com/cloudquery/cq-gen/codegen/source"
 	"github.com/cloudquery/cq-gen/codegen/template"
 	"github.com/cloudquery/cq-gen/naming"
 	"github.com/cloudquery/cq-gen/rewrite"
-	"github.com/cloudquery/cq-provider-sdk/provider/schema"
-	"github.com/hashicorp/go-hclog"
-	"github.com/iancoleman/strcase"
-	"github.com/jinzhu/inflection"
 )
 
 const (
@@ -102,6 +103,7 @@ func (tb TableBuilder) BuildTable(parentTable *TableDefinition, resourceCfg *con
 		parentTable:   parentTable,
 		Options:       resourceCfg.TableOptions,
 		Description:   resourceCfg.Description,
+		IgnoreInTests: resourceCfg.IgnoreInTests,
 		path:          resourceCfg.Path,
 	}
 	// will only mark table function as copied
@@ -138,6 +140,7 @@ func (tb TableBuilder) BuildTable(parentTable *TableDefinition, resourceCfg *con
 		}
 
 	}
+
 	if err := tb.buildColumns(table, obj, resourceCfg, meta); err != nil {
 		return nil, err
 	}

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cloudquery/cq-gen/code"
 	"github.com/creasty/defaults"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/cloudquery/cq-gen/code"
 )
 
 type Config struct {
@@ -65,6 +66,8 @@ type ResourceConfig struct {
 	AllowUnexported bool `hcl:"allow_unexported,optional"`
 	// Table options in the config
 	TableOptions *TableOptionsConfig `hcl:"options,block"`
+	// IgnoreInTests specifies whether this column should be ignored during non-nil checks in integration tests
+	IgnoreInTests bool `hcl:"ignore_in_tests,optional"`
 
 	// Column configurations we want to modify
 	Columns []ColumnConfig `hcl:"column,block"`

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -66,7 +66,7 @@ type ResourceConfig struct {
 	AllowUnexported bool `hcl:"allow_unexported,optional"`
 	// Table options in the config
 	TableOptions *TableOptionsConfig `hcl:"options,block"`
-	// IgnoreInTests specifies whether this column should be ignored during non-nil checks in integration tests
+	// IgnoreInTests specifies whether the table should be ignored during non-nil checks in integration tests
 	IgnoreInTests bool `hcl:"ignore_in_tests,optional"`
 
 	// Column configurations we want to modify

--- a/codegen/config/resource.go
+++ b/codegen/config/resource.go
@@ -40,6 +40,9 @@ func decodeResourceBody(ctx *hcl.EvalContext, body hcl.Body, labels []string) (*
 	if attr, exists := content.Attributes["description_path_parts"]; exists {
 		diags = append(diags, gohcl.DecodeExpression(attr.Expr, ctx, &resource.DescriptionPathParts)...)
 	}
+	if attr, exists := content.Attributes["ignore_in_tests"]; exists {
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, ctx, &resource.IgnoreInTests)...)
+	}
 	for _, b := range content.Blocks {
 		switch b.Type {
 		case "column":
@@ -147,6 +150,9 @@ func decodeRelationBlock(ctx *hcl.EvalContext, block *hcl.Block) (*RelationConfi
 	if attr, exists := content.Attributes["rename"]; exists {
 		diags = append(diags, gohcl.DecodeExpression(attr.Expr, ctx, &rel.Rename)...)
 	}
+	if attr, exists := content.Attributes["ignore_in_tests"]; exists {
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, ctx, &resource.IgnoreInTests)...)
+	}
 	return rel, diags
 }
 
@@ -246,6 +252,10 @@ var (
 			},
 			{
 				Name:     "disable_pluralize",
+				Required: false,
+			},
+			{
+				Name:     "ignore_in_tests",
 				Required: false,
 			},
 			{

--- a/codegen/definitions.go
+++ b/codegen/definitions.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 
-	"github.com/cloudquery/cq-gen/codegen/config"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
+
+	"github.com/cloudquery/cq-gen/codegen/config"
 )
 
 type TableDefinition struct {
@@ -16,6 +17,7 @@ type TableDefinition struct {
 	TableFuncName string
 	TableName     string
 	Description   string
+	IgnoreInTests bool
 	Columns       []ColumnDefinition
 	Relations     []*TableDefinition
 	// schema.TableResolver definition

--- a/codegen/table.gotpl
+++ b/codegen/table.gotpl
@@ -41,6 +41,9 @@
     {{- if .Options }}
     Options: schema.TableCreationOptions{PrimaryKeys: []string{ {{ .Options.PrimaryKeys|joinQuotes}} }},
     {{- end }}
+    {{- if .IgnoreInTests }}
+    IgnoreInTests: {{ $.IgnoreInTests }},
+    {{- end }}
     Columns: []schema.Column{
     {{- template "BuildColumns" .Columns }}
     },

--- a/codegen/tests/expected/relations/rename.go
+++ b/codegen/tests/expected/relations/rename.go
@@ -8,8 +8,9 @@ import (
 
 func Rename() *schema.Table {
 	return &schema.Table{
-		Name:     "test_relations_rename",
-		Resolver: fetchRelationsRename,
+		Name:          "test_relations_rename",
+		Resolver:      fetchRelationsRename,
+		IgnoreInTests: true,
 		Columns: []schema.Column{
 			{
 				Name: "column",
@@ -18,8 +19,9 @@ func Rename() *schema.Table {
 		},
 		Relations: []*schema.Table{
 			{
-				Name:     "test_base_renamed",
-				Resolver: fetchBaseRenamed,
+				Name:          "test_base_renamed",
+				Resolver:      fetchBaseRenamed,
+				IgnoreInTests: true,
 				Columns: []schema.Column{
 					{
 						Name:        "rename_cq_id",

--- a/codegen/tests/relations.hcl
+++ b/codegen/tests/relations.hcl
@@ -2,13 +2,15 @@ service          = "test"
 output_directory = "./tests/output/relations/"
 
 resource "test" "relations" "rename" {
-  path = "github.com/cloudquery/cq-gen/codegen/tests.SimpleRelation"
+  path              = "github.com/cloudquery/cq-gen/codegen/tests.SimpleRelation"
   disable_pluralize = true
+  ignore_in_tests   = true
 
   relation "test" "base" "relations" {
-    path = "github.com/cloudquery/cq-gen/codegen/tests.BaseStruct"
-    rename = "renamed"
+    path              = "github.com/cloudquery/cq-gen/codegen/tests.BaseStruct"
+    rename            = "renamed"
     disable_pluralize = true
+    ignore_in_tests   = true
   }
 }
 
@@ -17,7 +19,7 @@ resource "test" "relations" "user_relation" {
   path = "github.com/cloudquery/cq-gen/codegen/tests.SimpleRelation"
 
   user_relation "test" "base" "user" {
-    path = "github.com/cloudquery/cq-gen/codegen/tests.OtherStruct"
+    path              = "github.com/cloudquery/cq-gen/codegen/tests.OtherStruct"
     disable_pluralize = true
   }
 


### PR DESCRIPTION
For some resources, it is not possible to populate the tables in a reproducible way through Terraform right now. For these resources it is necessary to mark them as ignored in integration tests. By having support for this feature in cq-gen, we don't have to update the structs to ignore certain tables after every regeneration and can instead store this metadata in the generator config.