### PR TITLE
fix: The service property is parsed repeatedly, remove duplicate code

### DIFF
--- a/codegen/config/parser.go
+++ b/codegen/config/parser.go
@@ -24,9 +24,6 @@ func decodeConfig(body hcl.Body, diags hcl.Diagnostics) (*Config, hcl.Diagnostic
 	config := &Config{}
 	content, contentDiags := body.Content(configFileSchema)
 	diags = append(diags, contentDiags...)
-	if attr, exists := content.Attributes["service"]; exists {
-		diags = append(diags, gohcl.DecodeExpression(attr.Expr, nil, &config.Service)...)
-	}
 	if outputDirAttr, ok := content.Attributes["output_directory"]; ok {
 		diags = append(diags, gohcl.DecodeExpression(outputDirAttr.Expr, nil, &config.OutputDirectory)...)
 	}


### PR DESCRIPTION
Hello, when I read your code, I found that the parsing of the service attribute in the .hcl configuration file seems to be duplicated, maybe the duplicate code should be removed? 