### PR TITLE
fix: Better error message when loading package fails

### DIFF
--- a/code/finder.go
+++ b/code/finder.go
@@ -3,6 +3,7 @@ package code
 import (
 	"fmt"
 	"go/types"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -79,6 +80,14 @@ func (f Finder) FindObject(pkgName string, typeName string) (types.Object, error
 	pkg := f.pkgs.LoadWithTypes(pkgName)
 	if pkg == nil {
 		return nil, errors.Errorf("required package was not loaded: %s", fullName)
+	}
+
+	if len(pkg.Errors) > 0 {
+		msgs := make([]string, len(pkg.Errors))
+		for i := range pkg.Errors {
+			msgs[i] = pkg.Errors[i].Msg
+		}
+		return nil, errors.Errorf("failed to load package %s: %v", fullName, strings.Join(msgs, ","))
 	}
 
 	// then look for types directly

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-gen
 go 1.16
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.14.3
+	github.com/cloudquery/cq-provider-sdk v0.14.4
 	github.com/creasty/defaults v1.6.0
 	github.com/getkin/kin-openapi v0.83.0
 	github.com/google/go-cmp v0.5.8
@@ -11,10 +11,8 @@ require (
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jinzhu/inflection v1.0.0
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/pkg/errors v0.9.1
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/spf13/afero v1.8.2
 	github.com/stretchr/testify v1.8.0
 	github.com/thoas/go-funk v0.9.2
@@ -22,4 +20,9 @@ require (
 	github.com/zclconf/go-cty v1.10.0
 	golang.org/x/text v0.3.7
 	golang.org/x/tools v0.1.11
+)
+
+require (
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -214,8 +214,8 @@ github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
-github.com/cloudquery/cq-provider-sdk v0.14.3 h1:nba7Fez8l/6BEGDoKNZqLHkftrFTnQQOVECOqCzjNsA=
-github.com/cloudquery/cq-provider-sdk v0.14.3/go.mod h1:Zr/PbvBI6IQh6VZfWXcMsTPT+z7TzkGZxLtJO8lO2BM=
+github.com/cloudquery/cq-provider-sdk v0.14.4 h1:0ZwH7qxmhxmqRmEYFYeXu2ABqLJSJcmoNRl+8Cum0pw=
+github.com/cloudquery/cq-provider-sdk v0.14.4/go.mod h1:Zr/PbvBI6IQh6VZfWXcMsTPT+z7TzkGZxLtJO8lO2BM=
 github.com/cloudquery/faker/v3 v3.7.7 h1:vODOmAXGhxAacVrUOjr4Jti2lFhXgkPjG6/L3C2REgQ=
 github.com/cloudquery/faker/v3 v3.7.7/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
I ran into a situation where the error message returned by cq-gen was not very helpful and only said `failed to build resources: unable to find type github.com/cloudquery/cq-provider-sdk/provider/schema.TableResolver`. However, the problem was not actually that `schema.TableResolver` itself couldn't be found, it was that the entire `schema` package couldn't be loaded and contained this error internally:

```
missing go.sum entry for module providing package github.com/cloudquery/cq-provider-sdk/provider/schema; to add:
        go mod download github.com/cloudquery/cq-provider-sdk
```

With this change, the underlying error is bubbled up to the user to help with debugging in such cases.

This also bumps cq-provider-sdk to the latest available version. 