### PR TITLE
fix: Allow for forced generation of relation resolvers

### DIFF
--- a/codegen/builder.go
+++ b/codegen/builder.go
@@ -165,11 +165,12 @@ func (tb TableBuilder) BuildTable(parentTable *TableDefinition, resourceCfg *con
 func (tb TableBuilder) buildTableFunctions(table *TableDefinition, resource *config.ResourceConfig, meta BuildMeta) error {
 	var err error
 	hasResolver := resource.Resolver != nil
+	forceCustomGeneration := hasResolver && resource.Resolver.Generate
 	canGenerateResolverImplementation := table.parentTable != nil && len(meta.FieldParts) > 0
 	switch {
-	case hasResolver:
+	case hasResolver && !forceCustomGeneration:
 		table.Resolver, err = tb.buildResolverDefinition(table, resource.Resolver)
-	case canGenerateResolverImplementation:
+	case canGenerateResolverImplementation && !forceCustomGeneration:
 		table.Resolver, err = tb.getPathTableResolver(meta)
 	default:
 		table.Resolver, err = tb.buildResolverDefinition(table, &config.FunctionConfig{

--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -114,7 +114,7 @@ type FunctionConfig struct {
 	// Body to insert when function is generated, use with care, auto importing isn't supported in user defined bodies
 	Body string `hcl:"body,optional"`
 	// Path to a function to use.
-	Path string `hcl:"path"`
+	Path string `hcl:"path,optional"`
 	// Generate tells cq-gen to create the function code in template, usually set automatically.
 	// Setting to true will force function generation in template.
 	Generate bool `hcl:"generate,optional"`


### PR DESCRIPTION
There are cases where it is necessary to force the generation of relation resolver templates that can be modified by the user. Right now, users are unable to specify this because the `path` parameter is required. Removing this requirement and checking for `generate = true` makes it possible to manually write relation resolvers when it is necessary, as in this case: https://github.com/cloudquery/cq-provider-aws/pull/1387/files#diff-86e552535a84ced3cadd0ea570f37abb31da10f14fbd5511d7c3ff0347866e93R61-R63