### PR TITLE
fix: Properly split description sentences and remove trailing punctuation

### DIFF
--- a/codegen/generate_test.go
+++ b/codegen/generate_test.go
@@ -35,6 +35,7 @@ func Test_Generate(t *testing.T) {
 		{Name: "simple", Config: "./tests/base.hcl", Domain: "base", ResourceName: "simple"},
 		{Name: "complex", Config: "./tests/base.hcl", Domain: "base", ResourceName: "complex"},
 		{Name: "relations", Config: "./tests/base.hcl", Domain: "base", ResourceName: "relations"},
+		{Name: "descriptions", Config: "./tests/base.hcl", Domain: "base", ResourceName: "descriptions"},
 		{Name: "columns", Config: "./tests/columns.hcl", Domain: "columns", ResourceName: "columns"},
 		{Name: "embedded_prefix_skip", Config: "./tests/columns.hcl", Domain: "columns", ResourceName: "embedded_prefix_skip"},
 		{Name: "embedded_rename", Config: "./tests/columns.hcl", Domain: "columns", ResourceName: "embedded_rename"},

--- a/codegen/source/source.go
+++ b/codegen/source/source.go
@@ -42,8 +42,14 @@ type DescriptionParser interface {
 type DefaultDescriptionParser struct{}
 
 func (p *DefaultDescriptionParser) Parse(description string) string {
-	data := strings.SplitN(description, ". ", 2)[0]
-	return strings.TrimSpace(strings.ReplaceAll(data, "\n", " "))
+	// replace newlines with spaces
+	data := strings.ReplaceAll(description, "\n", " ")
+	// use only the first sentence from the description
+	data = strings.SplitN(data, ". ", 2)[0]
+	// trim trailing whitespace and fullstops
+	data = strings.TrimRight(data, " .")
+	// trim all remaining spaces
+	return strings.TrimSpace(data)
 }
 
 type UserDescriptionParser struct {

--- a/codegen/source/source_test.go
+++ b/codegen/source/source_test.go
@@ -12,6 +12,7 @@ func TestDefaultDescriptionParser_Parse(t *testing.T) {
 		{give: "sentence 1   .  ", want: "sentence 1"},
 		{give: "sentence 1. sentence 2", want: "sentence 1"},
 		{give: "sentence 1. sentence 2. sentence 3", want: "sentence 1"},
+		{give: "sentence 1.\nsentence 2", want: "sentence 1"},
 	}
 	p := DefaultDescriptionParser{}
 	for _, tc := range cases {

--- a/codegen/source/source_test.go
+++ b/codegen/source/source_test.go
@@ -2,6 +2,26 @@ package source
 
 import "testing"
 
+func TestDefaultDescriptionParser_Parse(t *testing.T) {
+	cases := []struct {
+		give string
+		want string
+	}{
+		{give: "sentence 1.", want: "sentence 1"},
+		{give: "sentence 1. ", want: "sentence 1"},
+		{give: "sentence 1   .  ", want: "sentence 1"},
+		{give: "sentence 1. sentence 2", want: "sentence 1"},
+		{give: "sentence 1. sentence 2. sentence 3", want: "sentence 1"},
+	}
+	p := DefaultDescriptionParser{}
+	for _, tc := range cases {
+		got := p.Parse(tc.give)
+		if got != tc.want {
+			t.Errorf("Parse(%q) = %q, want %q", tc.give, got, tc.want)
+		}
+	}
+}
+
 func TestNewUserDescriptionParser(t *testing.T) {
 	type expectation struct {
 		give string

--- a/codegen/tests/base.hcl
+++ b/codegen/tests/base.hcl
@@ -12,3 +12,7 @@ resource "test" "base" "complex" {
 resource "test" "base" "relations" {
   path = "github.com/cloudquery/cq-gen/codegen/tests.RelationStruct"
 }
+
+resource "test" "base" "descriptions" {
+  path = "github.com/cloudquery/cq-gen/codegen/tests.DescriptionStruct"
+}

--- a/codegen/tests/expected/base/descriptions.go
+++ b/codegen/tests/expected/base/descriptions.go
@@ -1,0 +1,40 @@
+package base
+
+import (
+	"context"
+
+	"github.com/cloudquery/cq-provider-sdk/provider/schema"
+)
+
+func Descriptions() *schema.Table {
+	return &schema.Table{
+		Name:        "test_base_descriptions",
+		Description: "DescriptionStruct describes itself as a struct",
+		Resolver:    fetchBaseDescriptions,
+		Columns: []schema.Column{
+			{
+				Name:        "simple",
+				Description: "Simple is a simple description",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "complex",
+				Description: "Value is a string",
+				Type:        schema.TypeString,
+			},
+			{
+				Name:        "created_at",
+				Description: "A sentence with a full stop that should get removed",
+				Type:        schema.TypeTimestamp,
+			},
+		},
+	}
+}
+
+// ====================================================================================================================
+//                                               Table Resolver Functions
+// ====================================================================================================================
+
+func fetchBaseDescriptions(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
+	panic("not implemented")
+}

--- a/codegen/tests/struct.go
+++ b/codegen/tests/struct.go
@@ -1,5 +1,7 @@
 package tests
 
+import "time"
+
 type BaseStruct struct {
 	IntValue  int
 	BoolValue bool
@@ -57,4 +59,19 @@ type DeepRelationalRelation struct {
 
 type DeepDeepRelationalRelation struct {
 	Relations []RelationalRelation
+}
+
+// DescriptionStruct describes itself as a struct.
+// Also, a second sentence.
+type DescriptionStruct struct {
+	// Simple is a simple description
+	Simple string
+
+	// Value is a string. It has more properties, but we will
+	// only tell you that it is a string. This is to make sure we have
+	// multiple sentences.
+	Complex string
+
+	// A sentence with a full stop that should get removed.
+	CreatedAt *time.Time
 }


### PR DESCRIPTION
https://github.com/cloudquery/cq-gen/pull/130 had a bug that left trailing full stops in some cases. This PR adds an end-to-end test case for description parsing and ensures that we handle cases with newlines and trailing full-stops in the expected manner.