### PR TITLE
feat: Add ability to use resolver templates

### DIFF
--- a/codegen/config/config.go
+++ b/codegen/config/config.go
@@ -113,6 +113,10 @@ type FunctionConfig struct {
 	Name string `hcl:"name,label"`
 	// Body to insert when function is generated, use with care, auto importing isn't supported in user defined bodies
 	Body string `hcl:"body,optional"`
+	// BodyTemplatePath should reference a Go string that represents a template
+	BodyTemplatePath string `hcl:"body_template_path,optional"`
+	// BodyTemplateParams
+	BodyTemplateParams map[string]string `hcl:"body_template_params,optional"`
 	// Path to a function to use.
 	Path string `hcl:"path,optional"`
 	// Generate tells cq-gen to create the function code in template, usually set automatically.

--- a/codegen/config/resource.go
+++ b/codegen/config/resource.go
@@ -172,6 +172,12 @@ func decodeFunctionBlock(ctx *hcl.EvalContext, block *hcl.Block) (*FunctionConfi
 	if attr, exists := content.Attributes["body"]; exists {
 		diags = append(diags, gohcl.DecodeExpression(attr.Expr, ctx, &rel.Body)...)
 	}
+	if attr, exists := content.Attributes["body_template_path"]; exists {
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, ctx, &rel.BodyTemplatePath)...)
+	}
+	if attr, exists := content.Attributes["body_template_params"]; exists {
+		diags = append(diags, gohcl.DecodeExpression(attr.Expr, ctx, &rel.BodyTemplateParams)...)
+	}
 	if attr, exists := content.Attributes["path"]; exists {
 		diags = append(diags, gohcl.DecodeExpression(attr.Expr, ctx, &rel.Path)...)
 	}

--- a/codegen/generate_test.go
+++ b/codegen/generate_test.go
@@ -44,6 +44,7 @@ func Test_Generate(t *testing.T) {
 		{Name: "resolvers_user_defined", Config: "./tests/resolvers.hcl", Domain: "resolvers", ResourceName: "user_defined"},
 		{Name: "resolvers_rename", Config: "./tests/resolvers.hcl", Domain: "resolvers", ResourceName: "rename_with_resolver"},
 		{Name: "with_params", Config: "./tests/resolvers.hcl", Domain: "resolvers", ResourceName: "with_params"},
+		{Name: "with_template", Config: "./tests/resolvers.hcl", Domain: "resolvers", ResourceName: "with_template"},
 		{Name: "user_defined_simple", Config: "./tests/user_defined.hcl", Domain: "user_defined", ResourceName: "simple"},
 		{Name: "user_defined_resolvers", Config: "./tests/user_defined.hcl", Domain: "user_defined", ResourceName: "resolvers"},
 		{Name: "relations_rename", Config: "./tests/relations.hcl", Domain: "relations", ResourceName: "rename"},

--- a/codegen/tests/expected/resolvers/with_template.go
+++ b/codegen/tests/expected/resolvers/with_template.go
@@ -33,5 +33,6 @@ func WithTemplates() *schema.Table {
 // ====================================================================================================================
 
 func fetchResolversWithTemplates(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
+	// GENERATED. Do not edit.
 	panic("hello from template params")
 }

--- a/codegen/tests/expected/resolvers/with_template.go
+++ b/codegen/tests/expected/resolvers/with_template.go
@@ -1,0 +1,37 @@
+package resolvers
+
+import (
+	"context"
+
+	"github.com/cloudquery/cq-provider-sdk/provider/schema"
+)
+
+func WithTemplates() *schema.Table {
+	return &schema.Table{
+		Name:     "test_resolvers_with_template",
+		Resolver: fetchResolversWithTemplates,
+		Columns: []schema.Column{
+			{
+				Name: "int_value",
+				Type: schema.TypeBigInt,
+			},
+			{
+				Name: "bool_value",
+				Type: schema.TypeBool,
+			},
+			{
+				Name:     "embedded_field_a",
+				Type:     schema.TypeBigInt,
+				Resolver: schema.PathResolver("Embedded.FieldA"),
+			},
+		},
+	}
+}
+
+// ====================================================================================================================
+//                                               Table Resolver Functions
+// ====================================================================================================================
+
+func fetchResolversWithTemplates(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
+	panic("hello from template params")
+}

--- a/codegen/tests/resolvers.hcl
+++ b/codegen/tests/resolvers.hcl
@@ -57,4 +57,14 @@ resource "test" "resolvers" "with_params" {
   }
 }
 
-
+// test resolver body templates
+resource "test" "resolvers" "with_template" {
+  path = "github.com/cloudquery/cq-gen/codegen/tests.BaseStruct"
+  resolver "templated_resolver" {
+    generate = true
+    body_template_path = "github.com/cloudquery/cq-gen/codegen/tests.SimpleTemplate"
+    body_template_params = {
+      "CustomMessage": "hello from template params"
+    }
+  }
+}

--- a/codegen/tests/templates.go
+++ b/codegen/tests/templates.go
@@ -1,0 +1,5 @@
+package tests
+
+const SimpleTemplate = `
+panic("{{ .CustomMessage }}")
+`

--- a/codegen/tests/templates.go
+++ b/codegen/tests/templates.go
@@ -1,5 +1,6 @@
 package tests
 
 const SimpleTemplate = `
+// GENERATED. Do not edit.
 panic("{{ .CustomMessage }}")
 `

--- a/providers/aws/templates.go
+++ b/providers/aws/templates.go
@@ -1,0 +1,35 @@
+package aws
+
+// PaginatorTemplate provides an example template from AWS.
+// Example values:
+//  Required:
+//    Package: xray
+//    ServiceName: Xray
+//    ReadAttribute: Groups
+//  Optional:
+//    Input: GetGroupsInput
+//    InputAttributes: {"Example": "\"value\""}
+//    NewPaginator: NewGetGroupsPaginator
+const PaginatorTemplate = `
+{{$NewPaginator := .NewPaginator}}
+{{- if not $NewPaginator -}}
+	{{$NewPaginator = print "NewGet" .ReadAttribute "Paginator"}}
+{{- end -}}
+{{- if .Input -}}
+	var input *{{.Package}}.{{.Input}}
+	{{if .InputAttributes}}
+		{{- range $attr, $val := .InputAttributes -}}
+		input.{{ $attr }} = {{ $val }}
+		{{ end }}
+	{{- end -}}
+{{- end -}}
+paginator := {{.Package}}.{{$NewPaginator}}(meta.(*client.Client).Services().{{.ServiceName}}, {{ if .Input }}input{{ else }}nil{{end}})
+for paginator.HasMorePages() {
+	v, err := paginator.NextPage(ctx)
+	if err != nil {
+		return diag.WrapError(err)
+	}
+	res <- v.{{.ReadAttribute}}
+}
+return nil
+`

--- a/providers/aws/templates.go
+++ b/providers/aws/templates.go
@@ -11,6 +11,7 @@ package aws
 //    InputAttributes: {"Example": "\"value\""}
 //    NewPaginator: NewGetGroupsPaginator
 const PaginatorTemplate = `
+// GENERATED from {{.TemplatePath}}. Do not edit.
 {{$NewPaginator := .NewPaginator}}
 {{- if not $NewPaginator -}}
 	{{$NewPaginator = print "NewGet" .ReadAttribute "Paginator"}}


### PR DESCRIPTION
This adds new functionality to cq-gen to generate a resolver function body from a given template. 

For example, a resolver can be defined like this:

```
  resolver "templated" {
    generate = true
    body_template_path = "github.com/cloudquery/cq-gen/providers/aws.PaginatorTemplate"
    body_template_params = {
      "Package": "xray",
      "ServiceName": "Xray",
      "ReadAttribute": "Groups",
    }
  }
```

and this will generate a function like this:

```
func fetchXrayGroups(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
	// GENERATED from github.com/cloudquery/cq-gen/providers/aws.PaginatorTemplate. Do not edit.
	paginator := xray.NewGetGroupsPaginator(meta.(*client.Client).Services().Xray, nil)
	for paginator.HasMorePages() {
		v, err := paginator.NextPage(ctx)
		if err != nil {
			return diag.WrapError(err)
		}
		res <- v.Groups
	}
	return nil
}
```

## Notes

- Here is a PR with a couple of examples using this: https://github.com/cloudquery/cloudquery/pull/1506
- The template should be a constant string stored somewhere in a Go module. 
- For now I've placed the AWS Paginator template in this repo. I imagine we might move it to the cloudquery monorepo at some point.